### PR TITLE
Office365 channels: Add refresh token authentication

### DIFF
--- a/Src/Common/FSecure/C3/Interfaces/Channels/Office365.h
+++ b/Src/Common/FSecure/C3/Interfaces/Channels/Office365.h
@@ -20,7 +20,8 @@ namespace FSecure::C3::Interfaces::Channels
 			, m_OutboundDirectionName{ arguments.Read<std::string>() }
 			, m_Username{ arguments.Read<SecureString>() }
 			, m_Password{ arguments.Read<SecureString>() }
-			, m_ClientKey{ arguments.Read<SecureString>() }
+			, m_ClientId{ arguments.Read<SecureString>() }
+			, m_UserAgent{ arguments.Read<SecureString>() }
 		{
 			FSecure::Utils::DisallowChars({ m_InboundDirectionName, m_OutboundDirectionName }, OBF(R"(;/?:@&=+$,)"));
 
@@ -28,7 +29,15 @@ namespace FSecure::C3::Interfaces::Channels
 			if (auto winProxy = WinTools::GetProxyConfiguration(); !winProxy.empty())
 				this->m_ProxyConfig = (winProxy == OBF(L"auto")) ? WebProxy(WebProxy::Mode::UseAutoDiscovery) : WebProxy(winProxy);
 
-			RefreshAccessToken();
+			FSecure::Utils::DebugPrint(OBF("Using m_InboundDirectionName: ") + m_InboundDirectionName);
+			FSecure::Utils::DebugPrint(OBF("Using m_OutboundDirectionName: ") + m_OutboundDirectionName);
+			FSecure::Utils::DebugPrint(OBF("Using m_Username: ") + Convert<Utf8>(m_Username.Decrypt()));
+			FSecure::Utils::DebugPrint(OBF("Using m_Password: ") + Convert<Utf8>(m_Password.Decrypt()));
+			FSecure::Utils::DebugPrint(OBF("Using m_ClientId: ") + Convert<Utf8>(m_ClientId.Decrypt()));
+			FSecure::Utils::DebugPrint(OBF("Using m_UserAgent: ") + Convert<Utf8>(m_UserAgent.Decrypt()));
+
+			// Initial requesting of the refresh token
+			RefreshRefreshToken();
 		}
 
 		/// Get channel capability.
@@ -40,7 +49,7 @@ namespace FSecure::C3::Interfaces::Channels
 		/// @param id of task.
 		void RemoveItem(std::string const& id)
 		{
-			auto webClient = HttpClient{ Convert<Utf16>(Derived::ItemEndpoint.Decrypt()  + SecureString{id}), m_ProxyConfig };
+			auto webClient = HttpClient{ Convert<Utf16>(Derived::ItemEndpoint.Decrypt() + SecureString{id}), m_ProxyConfig };
 			auto request = CreateAuthRequest(Method::DEL);
 			auto resp = webClient.Request(request);
 
@@ -56,37 +65,89 @@ namespace FSecure::C3::Interfaces::Channels
 				RemoveItem(element.at(OBF("id")));
 		}
 
-		/// Requests a new access token using the refresh token
+		/// Requests a new refresh token using username+password. Also refreshes the access token.
 		/// @throws std::exception if token cannot be refreshed.
-		void RefreshAccessToken()
+		void RefreshRefreshToken()
 		{
-			try
-			{
-				//Token endpoint
+			FSecure::Utils::DebugPrint(OBF("Refreshing refresh token."));
+			try {
 				auto webClient = HttpClient{ Convert<Utf16>(Derived::TokenEndpoint.Decrypt()), m_ProxyConfig };
 
 				auto request = HttpRequest{ Method::POST };
+				request.SetHeader(Header::UserAgent, Convert<Utf16>(m_UserAgent.Decrypt()));
 				auto requestBody = SecureString{};
 				requestBody += OBF("grant_type=password");
 				requestBody += OBF("&scope=");
 				requestBody += Derived::Scope.Decrypt();
 				requestBody += OBF("&username=");
-				requestBody += m_Username.Decrypt();
+				requestBody += Uri::EncodeData(ByteView(m_Username.Decrypt()));
 				requestBody += OBF("&password=");
-				requestBody += m_Password.Decrypt();
+				requestBody += Uri::EncodeData(ByteView(m_Password.Decrypt()));
 				requestBody += OBF("&client_id=");
-				requestBody += m_ClientKey.Decrypt();
+				requestBody += m_ClientId.Decrypt();
 
 				request.SetData(ContentType::ApplicationXWwwFormUrlencoded, { requestBody.begin(), requestBody.end() });
 				auto resp = webClient.Request(request);
-				EvaluateResponse(resp, false);
 
-				auto data = json::parse(resp.GetData());
-				m_Token = data[OBF("access_token")].get<std::string>();
+				if (resp.GetStatusCode() == StatusCode::OK) {
+					auto data = json::parse(resp.GetData());
+					m_AccessTokenExpiryTime = FSecure::Utils::TimeSinceEpoch() + data[OBF("expires_in")].get<int32_t>(); // Set the new expiry time for this access token
+					m_AccessToken = data[OBF("access_token")].get<std::string>();
+					m_RefreshToken = data[OBF("refresh_token")].get<std::string>();
+					FSecure::Utils::DebugPrint(OBF("Refresh token refreshed."));
+					FSecure::Utils::DebugPrint(OBF("Access token refreshed; new refresh in ") + std::to_string(data[OBF("expires_in")].get<int32_t>()) + OBF(" seconds."));
+				}
+				else 
+				{
+					throw std::runtime_error{ OBF("Non 200 response: ") + std::to_string(resp.GetStatusCode()) + OBF("\n") + ((std::string) resp.GetData()) };
+				}
 			}
-			catch (std::exception & exception)
+			catch (std::exception& exception)
 			{
-				throw std::runtime_error{ OBF_STR("Cannot refresh token: ") + exception.what() };
+				throw std::runtime_error{ OBF_STR("Cannot refresh the refresh token: ") + exception.what() };
+			}
+		}
+
+		/// Requests a new access token using the refresh token
+		/// @throws std::exception if access token cannot be refreshed.
+		void RefreshAccessToken()
+		{
+			FSecure::Utils::DebugPrint(OBF("Refreshing access token."));
+			try
+			{
+				auto webClient = HttpClient{ Convert<Utf16>(Derived::TokenEndpoint.Decrypt()), m_ProxyConfig };
+
+				auto request = HttpRequest{ Method::POST };
+				request.SetHeader(Header::UserAgent, Convert<Utf16>(m_UserAgent.Decrypt()));
+				auto requestBody = SecureString{};
+				requestBody += OBF("grant_type=refresh_token");
+				requestBody += OBF("&scope=");
+				requestBody += Uri::EncodeData(ByteView(Derived::Scope.Decrypt()));
+				requestBody += OBF("&client_id=");
+				requestBody += Uri::EncodeData(ByteView(m_ClientId.Decrypt()));
+				requestBody += OBF("&refresh_token=");
+				requestBody += Uri::EncodeData(ByteView(m_RefreshToken.Decrypt()));
+
+				request.SetData(ContentType::ApplicationXWwwFormUrlencoded, { requestBody.begin(), requestBody.end() });
+				auto resp = webClient.Request(request);
+
+				if (resp.GetStatusCode() == StatusCode::Unauthorized)
+				{
+					FSecure::Utils::DebugPrint(OBF("Refresh token expired, requesting a new one using username+password."));
+					RefreshRefreshToken();
+				}
+				else
+				{
+					EvaluateResponse(resp, false);
+					auto data = json::parse(resp.GetData());
+					m_AccessToken = data[OBF("access_token")].get<std::string>();
+					m_AccessTokenExpiryTime = FSecure::Utils::TimeSinceEpoch() + data[OBF("expires_in")].get<int32_t>(); // Set the new expiry time for this access token
+					FSecure::Utils::DebugPrint(OBF("Access token refreshed; new refresh in ") + std::to_string(data[OBF("expires_in")].get<int32_t>()) + OBF(" seconds."));
+				}
+			}
+			catch (std::exception& exception)
+			{
+				throw std::runtime_error{ OBF_STR("Cannot refresh access token: ") + exception.what() };
 			}
 		}
 
@@ -103,28 +164,33 @@ namespace FSecure::C3::Interfaces::Channels
 				auto retryAfterHeader = resp.GetHeader(Header::RetryAfter);
 				auto delay = !retryAfterHeader.empty() ? stoul(retryAfterHeader) : FSecure::Utils::GenerateRandomValue(10, 20);
 				s_TimePoint = std::chrono::steady_clock::now() + std::chrono::seconds{ delay };
-				throw std::runtime_error{ OBF("Too many requests") };
+				throw std::runtime_error{ OBF("HTTP 429 - Too many requests") };
 			}
 
 			if (resp.GetStatusCode() == StatusCode::Unauthorized)
 			{
 				if (tryRefreshingToken)
 					RefreshAccessToken();
-				throw std::runtime_error{ OBF("HTTP 401 - Token being refreshed") };
+				throw std::runtime_error{ OBF("HTTP 401 - Token being refreshed") }; // Throwing an exception will retry the operation
 			}
 
 			if (resp.GetStatusCode() == StatusCode::BadRequest)
 				throw std::runtime_error{ OBF("Bad Request") };
 
-			throw std::runtime_error{ OBF("Non 200 http response.") + std::to_string(resp.GetStatusCode()) };
+			throw std::runtime_error{ OBF("Non 200 response:") + std::to_string(resp.GetStatusCode()) };
 		}
 
 		/// Create request using internally stored token.
 		/// @param method, request type.
 		WinHttp::HttpRequest CreateAuthRequest(WinHttp::Method method = WinHttp::Method::GET)
 		{
+			if (m_AccessTokenExpiryTime <= FSecure::Utils::TimeSinceEpoch()) {
+				// Access token has expired, let's request a new one
+				FSecure::Utils::DebugPrint(OBF("Access token expired, refreshing!"));
+				RefreshAccessToken();
+			}
 			auto request = HttpRequest{ method };
-			request.SetHeader(Header::Authorization, Convert<Utf16>(OBF_SEC("Bearer ") + m_Token.Decrypt()));
+			request.SetHeader(Header::Authorization, Convert<Utf16>(OBF_SEC("Bearer ") + m_AccessToken.Decrypt()));
 			return request;
 		}
 
@@ -150,11 +216,14 @@ namespace FSecure::C3::Interfaces::Channels
 			return json::parse(resp.GetData());
 		}
 
+		/// Timestamp when the access token expires, and we should retrieve a new token before making any request
+		int32_t m_AccessTokenExpiryTime;
+
 		/// In/Out names on the server.
 		std::string m_InboundDirectionName, m_OutboundDirectionName;
 
-		/// Username, password, client key and token for authentication.
-		Crypto::String m_Username, m_Password, m_ClientKey, m_Token;
+		/// Username, password, client id, user-agent header and tokens for authentication.
+		Crypto::String m_Username, m_Password, m_ClientId, m_UserAgent, m_AccessToken, m_RefreshToken;
 
 		/// Store any relevant proxy info
 		WinHttp::WebProxy m_ProxyConfig;
@@ -209,9 +278,15 @@ const char* FSecure::C3::Interfaces::Channels::Office365<Derived>::GetCapability
 			},
 			{
 				"type": "string",
-				"name": "Client Key/ID",
+				"name": "Client ID",
 				"min": 1,
 				"description": "The GUID of the registered application."
+			},
+			{
+				"type": "string",
+				"name": "User Agent",
+				"min": 1,
+				"description": "The User-Agent header to use when making HTTP requests"
 			}
 		]
 	},

--- a/Src/Common/FSecure/C3/Interfaces/Channels/OneDrive365RestFile.cpp
+++ b/Src/Common/FSecure/C3/Interfaces/Channels/OneDrive365RestFile.cpp
@@ -19,7 +19,7 @@ FSecure::Crypto::String FSecure::C3::Interfaces::Channels::OneDrive365RestFile::
 FSecure::Crypto::String FSecure::C3::Interfaces::Channels::OneDrive365RestFile::ItemEndpoint = OBF("https://graph.microsoft.com/v1.0/me/drive/items/");
 FSecure::Crypto::String FSecure::C3::Interfaces::Channels::OneDrive365RestFile::ListEndpoint = OBF("https://graph.microsoft.com/v1.0/me/drive/root/children");
 FSecure::Crypto::String FSecure::C3::Interfaces::Channels::OneDrive365RestFile::TokenEndpoint = OBF("https://login.windows.net/organizations/oauth2/v2.0/token");
-FSecure::Crypto::String FSecure::C3::Interfaces::Channels::OneDrive365RestFile::Scope = OBF("files.readwrite.all");
+FSecure::Crypto::String FSecure::C3::Interfaces::Channels::OneDrive365RestFile::Scope = OBF("https://graph.microsoft.com/.default offline_access");
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 FSecure::C3::Interfaces::Channels::OneDrive365RestFile::OneDrive365RestFile(ByteView arguments)

--- a/Src/Common/FSecure/CppTools/Utils.h
+++ b/Src/Common/FSecure/CppTools/Utils.h
@@ -4,6 +4,7 @@
 #include <string_view>
 #include <vector>
 #include <chrono>
+#include <iostream>
 
 #ifndef OBF
 #	define OBF(x) x
@@ -248,5 +249,12 @@ namespace FSecure::Utils
 	{
 		for (auto word : words)
 			DisallowChars(word, forbiddenChars);
+	}
+
+	/// Print a debug message to stdout.
+	inline void DebugPrint(std::string msg) {
+#ifdef _DEBUG
+		std::cout << OBF("[DEBUG] ") << msg << std::endl;
+#endif
 	}
 }


### PR DESCRIPTION
This PR adds refresh token authentication to both Office365 channels (OneDrive365RestFile, Outlook365RestTask). 

The current version of C3 uses [OAuth 2.0 Resource Owner Password Credentials (ROPC)](https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth-ropc) to request & refresh OAuth access tokens in the Office365 channels. Access tokens expire every hour (by default) and need to be refreshed after that time. C3 currently only uses the ROPC authentication mechanism, which sends the username+password over the wire every time it needs to re-authenticate.

This pull-request improves the authentication flow by requesting, storing and re-using the `refresh_token` provided by the OAuth login endpoint. The `refresh_token` is then used to request new access tokens. As a fallback (e.g. in case the refresh token expires), C3 will automatically request new tokens using ROPC.

Additionally I've added a User Agent channel option, which sets the 'User-Agent' header in all HTTP requests. Using a well-known User-Agent helps with blending in with legitimate traffic (OPSEC).