### PR TITLE
Update link to blogpost in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ C3 (Custom Command and Control) is a tool that allows Red Teams to rapidly devel
 
 ## Usage
 
-See [this](https://labs.mwrinfosecurity.com/tools/c3) blog post for a detailed tutorial. 
+See [this](https://labs.withsecure.com/tools/c3) blog post for a detailed tutorial. 
 
 For contribution guide (how to develop a Channel tutorials), see [this page](CONTRIBUTING.md).
 

--- a/Res/C2ImplementationGuide.md
+++ b/Res/C2ImplementationGuide.md
@@ -22,7 +22,7 @@ Finally, for ease of integration it helps if the chosen framework provides acces
 
 At a high level, the objective of integration would result in the communication flow described in the figure below:
 
-<img src="images\C2ImplementationGuide\01.png"/>
+![](./Images/C2ImplementationGuide/01.png)
 
 
 
@@ -137,7 +137,7 @@ FSecure::ByteView FSecure::C3::Interfaces::Connectors::Covenant::GetCapability()
 ```
 The resulting form is shown in the next figure. Note that no changes were made to the actual web interface of C3.
 
-<img src="images/AttachingCovenantGrunt/figure1.png" />
+![](./Images/AttachingCovenantGrunt/figure1.png)
 
 **Stage 2 - Handle User Input**
 

--- a/Res/RelayGuides/AttachingCovenantGrunt.md
+++ b/Res/RelayGuides/AttachingCovenantGrunt.md
@@ -4,13 +4,13 @@ This section demonstrates how to use the new integration of the Covenant C2 fram
 
 2. Fill in the form, these options will be used to create a BridgeListener in Covenant on the specified port.
 
-<img src="../images/AttachingCovenantGrunt/figure1.png"/>
+![](../Images/AttachingCovenantGrunt/figure1.png)
 
 3. Run the C2Bridge project on the same system as C3’s gateway. If TCP port 8000 was chosen as the C2Bridge port, then the correct arguments for C2Bridge would be “dotnet C2Bridge.dll covenant-host-ip 8000 8000”.
 
 4. In order to stage an SMB Grunt, select a running Node Relay’s command centre and select AddPeripheralGrunt. 
 
-<img src="../images/AttachingCovenantGrunt/figure2.png"/>
+![](../Images/AttachingCovenantGrunt/figure2.png)
 
 
 

--- a/Res/ShellcodeUsageGuide.md
+++ b/Res/ShellcodeUsageGuide.md
@@ -6,7 +6,7 @@ It is now possible for raw shellcode to be downloaded from the web interface. Th
 
 3. Within the Relay Setup window, select “shellcode” from the target suffix dropdown. A new set of options will be provided, as shown in the next image.
 
-<img src="images/ShellcodeUsageGuide/figure3.png"/>
+![figure3.png](./Images/ShellcodeUsageGuide/figure3.png)
 
 1. Select the various options that will be passed to Donut. Note that it is strongly advised to use compression, of which the apLib option is the best.
 


### PR DESCRIPTION
The current link (https://labs.mwrinfosecurity.com/tools/c3) has an expired certificate and redirects to `labs.withsecure.com` anyway.

Edit: Speaking of which, the blog post has some outdated content, such as "The Preferred location is: “Src/Common/MWR/C3/Interfaces/Channels” or its sub folder." (https://labs.withsecure.com/tools/c3). Is it possible to contribute updates to the blog? Is it worth maintaining or has the post been superseded by the [`CONTRIBUTING.md` file](https://github.com/WithSecureLabs/C3/blob/master/CONTRIBUTING.md)?